### PR TITLE
Adding readState() and readLinearizedTempC() functions

### DIFF
--- a/Adafruit_MAX31855/MAX31855.py
+++ b/Adafruit_MAX31855/MAX31855.py
@@ -24,29 +24,6 @@ import math
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
 
-# Default I2C address for device.
-MCP9808_I2CADDR_DEFAULT        = 0x18
-
-# Register addresses.
-MCP9808_REG_CONFIG             = 0x01
-MCP9808_REG_UPPER_TEMP         = 0x02
-MCP9808_REG_LOWER_TEMP         = 0x03
-MCP9808_REG_CRIT_TEMP          = 0x04
-MCP9808_REG_AMBIENT_TEMP       = 0x05
-MCP9808_REG_MANUF_ID           = 0x06
-MCP9808_REG_DEVICE_ID          = 0x07
-
-# Configuration register values.
-MCP9808_REG_CONFIG_SHUTDOWN    = 0x0100
-MCP9808_REG_CONFIG_CRITLOCKED  = 0x0080
-MCP9808_REG_CONFIG_WINLOCKED   = 0x0040
-MCP9808_REG_CONFIG_INTCLR      = 0x0020
-MCP9808_REG_CONFIG_ALERTSTAT   = 0x0010
-MCP9808_REG_CONFIG_ALERTCTRL   = 0x0008
-MCP9808_REG_CONFIG_ALERTSEL    = 0x0002
-MCP9808_REG_CONFIG_ALERTPOL    = 0x0002
-MCP9808_REG_CONFIG_ALERTMODE   = 0x0001
-
 
 class MAX31855(object):
     """Class to represent an Adafruit MAX31855 thermocouple temperature
@@ -107,6 +84,87 @@ class MAX31855(object):
             v >>= 18
         # Scale by 0.25 degrees C per bit and return value.
         return v * 0.25
+
+    def readState(self):
+        """Return dictionary containing fault codes and hardware problems
+        """
+        v = self._read32()
+        return {
+            'openCircuit': (v & (1 << 0)) > 0,
+            'shortGND': (v & (1 << 1)) > 0,
+            'shortVCC': (v & (1 << 2)) > 0,
+            'fault': (v & (1 << 16)) > 0
+        }
+
+    def readLinearizedTempC(self):
+        """Return the NIST-linearized thermocouple temperature value in degrees celsius.
+        See https://learn.adafruit.com/calibrating-sensors/maxim-31855-linearization for more info.
+        """
+        # MAX31855 thermocouple voltage reading in mV
+        thermocoupleVoltage = (self.readTempC() - self.readInternalC()) * 0.041276
+        # MAX31855 cold junction voltage reading in mV
+        coldJunctionTemperature = self.readInternalC()
+        coldJunctionVoltage = (-0.176004136860E-01 +
+            0.389212049750E-01  * coldJunctionTemperature +
+            0.185587700320E-04  * math.pow(coldJunctionTemperature, 2.0) +
+            -0.994575928740E-07 * math.pow(coldJunctionTemperature, 3.0) +
+            0.318409457190E-09  * math.pow(coldJunctionTemperature, 4.0) +
+            -0.560728448890E-12 * math.pow(coldJunctionTemperature, 5.0) +
+            0.560750590590E-15  * math.pow(coldJunctionTemperature, 6.0) +
+            -0.320207200030E-18 * math.pow(coldJunctionTemperature, 7.0) +
+            0.971511471520E-22  * math.pow(coldJunctionTemperature, 8.0) +
+            -0.121047212750E-25 * math.pow(coldJunctionTemperature, 9.0) +
+            0.118597600000E+00  * math.exp(-0.118343200000E-03 * math.pow((coldJunctionTemperature-0.126968600000E+03), 2.0)))
+        # cold junction voltage + thermocouple voltage
+        voltageSum = thermocoupleVoltage + coldJunctionVoltage
+        # calculate corrected temperature reading based on coefficients for 3 different ranges
+        # float b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10;
+        if thermocoupleVoltage < 0:
+            b0 = 0.0000000E+00
+            b1 = 2.5173462E+01
+            b2 = -1.1662878E+00
+            b3 = -1.0833638E+00
+            b4 = -8.9773540E-01
+            b5 = -3.7342377E-01
+            b6 = -8.6632643E-02
+            b7 = -1.0450598E-02
+            b8 = -5.1920577E-04
+            b9 = 0.0000000E+00
+        elif thermocoupleVoltage < 20.644:
+            b0 = 0.000000E+00
+            b1 = 2.508355E+01
+            b2 = 7.860106E-02
+            b3 = -2.503131E-01
+            b4 = 8.315270E-02
+            b5 = -1.228034E-02
+            b6 = 9.804036E-04
+            b7 = -4.413030E-05
+            b8 = 1.057734E-06
+            b9 = -1.052755E-08
+        elif thermocoupleVoltage < 54.886:
+            b0 = -1.318058E+02
+            b1 = 4.830222E+01
+            b2 = -1.646031E+00
+            b3 = 5.464731E-02
+            b4 = -9.650715E-04
+            b5 = 8.802193E-06
+            b6 = -3.110810E-08
+            b7 = 0.000000E+00
+            b8 = 0.000000E+00
+            b9 = 0.000000E+00
+        else:
+            # TODO: handle error - out of range
+            return 0
+        return (b0 +
+            b1 * voltageSum +
+            b2 * pow(voltageSum, 2.0) +
+            b3 * pow(voltageSum, 3.0) +
+            b4 * pow(voltageSum, 4.0) +
+            b5 * pow(voltageSum, 5.0) +
+            b6 * pow(voltageSum, 6.0) +
+            b7 * pow(voltageSum, 7.0) +
+            b8 * pow(voltageSum, 8.0) +
+            b9 * pow(voltageSum, 9.0))
 
     def _read32(self):
         # Read 32 bits from the SPI bus.


### PR DESCRIPTION
**Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.** 
- removed a block of unused MCP9808 variables
- added a `getState()` function to read and return the fault codes made available by the MAX31855 chip
- added a `readLinearizedTempC()` function to return the NIST-linearized thermocouple temperature value in degrees Celsius, which improves the accuracy of the temperature calculation given that the chip does not perform linearization internally (the error can be especially bad at the extremes of the temperature ranges).  See https://learn.adafruit.com/calibrating-sensors/maxim-31855-linearization for a full discussion.  This code is directly ported from jh421797's C code.

**Describe any known limitations with your change.**

None known

**Please run any tests or examples that can exercise your modified code.** 

These are new functions, so should not break existing code.  The linearized temperatures were verified using a Fluke 726 calibrator to simulate a temperature range from -200C to +1370C into the MAX31855 breakout board.  See attached Excel spreadsheet for the raw data.

[MAX31855-calibration.xlsx](https://github.com/adafruit/Adafruit_Python_MAX31855/files/290486/MAX31855-calibration.xlsx)
